### PR TITLE
#36: add `pure = true` to container api (closes #36)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "buildo-state": "^0.4.0",
     "lodash": "^4.17.4",
     "react-avenger": "^2.1.0",
-    "revenge": "0.4.5",
+    "revenge": "^0.4.6",
     "tcomb-react": "0.9.0"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,8 @@ const decorator = ({ declareQueries, declareCommands, declareConnect }) => (Comp
     connect, local, queries, commands,
     reduceQueryProps: reduceQueryPropsFn,
     mapProps,
-    propTypes: __props
+    propTypes: __props,
+    pure: __pure = true
   } = ContainerConfig(config);
 
   const displayName = _displayName(Component, 'Container');
@@ -96,7 +97,8 @@ const decorator = ({ declareQueries, declareCommands, declareConnect }) => (Comp
     localizeProps,
     declaredQueries,
     reduceQueryProps,
-    declaredCommands
+    declaredCommands,
+    __pure && pure
   ]));
 
   const getLocals = mapProps || pick([
@@ -107,7 +109,6 @@ const decorator = ({ declareQueries, declareCommands, declareConnect }) => (Comp
 
   @composedDecorators
   @skinnable(contains(Component))
-  @pure
   @props(propsTypes)
   class ContainerFactoryWrapper extends React.Component { // eslint-disable-line react/no-multi-comp
 


### PR DESCRIPTION
Closes #36

## Test Plan

### tests performed

tested locally with new revenge version on ipercron

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
