### PR TITLE
#49: extract and export here `cacheQueryValues` `reduceQueryProps` function (closes #49)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ import _declareQueries from 'react-avenger/lib/queries';
 import _declareCommands from 'react-avenger/lib/commands';
 import { defaultIsReady } from 'react-avenger/lib/loading';
 import _displayName from './displayName';
-import reduceQueryPropsDecorator from './reduceQueryPropsDecorator';
+import reduceQueryPropsDecorator from './reduceQueryPropsDecorator/decorator';
+export { cacheQueryValues } from './reduceQueryPropsDecorator/reducers';
 import localizePropsDecorator from './localizePropsDecorator';
 
 const stripUndef = omitByF(isUndefined);

--- a/src/reduceQueryPropsDecorator/decorator.js
+++ b/src/reduceQueryPropsDecorator/decorator.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import pick from 'lodash/fp/pick';
-import displayName from './displayName';
+import displayName from '../displayName';
 import { t } from 'tcomb-react';
 
 const ReadyState = t.interface({

--- a/src/reduceQueryPropsDecorator/reducers.js
+++ b/src/reduceQueryPropsDecorator/reducers.js
@@ -1,0 +1,26 @@
+import pickBy from 'lodash/fp/pickBy';
+import mapValues from 'lodash/mapValues';
+
+const stripUndefineds = pickBy(x => typeof x !== 'undefined');
+
+const mergeReadyState = (accReadyState = {}, newReadyState) => {
+  return mapValues(newReadyState, (newQueryRs, queryName) => {
+    const accQueryRs = accReadyState[queryName] || {};
+    return {
+      ...newQueryRs,
+      ready: newQueryRs.ready || accQueryRs.ready || false // possibly remain "ready" based on old props
+    };
+  });
+};
+
+export const cacheQueryValues = (acc = {}, newProps) => {
+  const nextProps = {
+    ...acc,
+    ...stripUndefineds(newProps),
+    readyState: mergeReadyState(acc.readyState, newProps.readyState)
+  };
+  return {
+    accumulator: nextProps,
+    props: nextProps
+  };
+};


### PR DESCRIPTION
Closes #49

## Test Plan

### tests performed

tested locally on aliniq

usage would be:
```js
import container, { cacheQueryValues } from 'container'

export default container(Component, {
  reduceQueryProps: cacheQueryValues
})
```

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
