### PR TITLE
#53: react-avenger/queries `querySync` should be set to `true` when running on node (closes #53)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ const decorator = ({ declareQueries, declareCommands, declareConnect }) => (Comp
   const containerNamespace = `${localPrefix}-${displayName}-${_containerCounter}__`;
   const localizeProps = local && localizePropsDecorator({ containerNamespace, local });
 
-  const declaredQueries = queries && declareQueries(queries);
+  const declaredQueries = queries && declareQueries(queries, { querySync: typeof window === 'undefined' });
   const queriesInputTypes = queries && declaredQueries.InputType || {};
   const declaredCommands = commands && declareCommands(commands);
   const commandsInputTypes = commands && declaredCommands.InputType || {};


### PR DESCRIPTION
Closes #53

## Test Plan

### tests performed

tested it is indeed passed `=true` on lexdoit

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
