### PR TITLE
#58: Support new state API (closes #58)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,8 @@ const decorator = ({ declareQueries, declareCommands, declareConnect }) => (Comp
   const declaredCommands = commands && declareCommands(commands);
   const commandsInputTypes = commands && Object.keys(declaredCommands.InputType) || [];
   const declaredConnect = (connect || local || queries || commands) && declareConnect([
-    ...omit(queriesInputTypes, Object.keys(local)),
-    ...omit(commandsInputTypes, Object.keys(local)),
+    ...omit(queriesInputTypes, Object.keys(local || {})),
+    ...omit(commandsInputTypes, Object.keys(local || {})),
     ...(connect || [])
   ].concat(local ? ['___local'] : []));
   const reduceQueryProps = queries && reduceQueryPropsFn && reduceQueryPropsDecorator({ queries, reducer: reduceQueryPropsFn });

--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,8 @@ const decorator = ({ declareQueries, declareCommands, declareConnect }) => (Comp
   const declaredCommands = commands && declareCommands(commands);
   const commandsInputTypes = commands && Object.keys(declaredCommands.InputType) || [];
   const declaredConnect = (connect || local || queries || commands) && declareConnect([
-    ...omit(queriesInputTypes, Object.keys(local || {})),
-    ...omit(commandsInputTypes, Object.keys(local || {})),
+    ...difference(queriesInputTypes, Object.keys(local || {})),
+    ...difference(commandsInputTypes, Object.keys(local || {})),
     ...(connect || [])
   ].concat(local ? ['___local'] : []));
   const reduceQueryProps = queries && reduceQueryPropsFn && reduceQueryPropsDecorator({ queries, reducer: reduceQueryPropsFn });

--- a/src/localizePropsDecorator.js
+++ b/src/localizePropsDecorator.js
@@ -27,9 +27,7 @@ export default function localizePropsDecorator({ containerNamespace, local }) {
   const decorator = Component => {
     @skinnable(contains(Component))
     @props({
-      ___local: t.maybe(t.interface({
-        ...globalizedLocalTypes
-      }, { strict: false })),
+      ___local: t.maybe(t.interface(globalizedLocalTypes, { strict: false })),
       transition: t.Function
     }, { strict: false })
     class LocalizePropsWrapper extends React.Component {
@@ -51,22 +49,19 @@ export default function localizePropsDecorator({ containerNamespace, local }) {
         };
       }, {});
 
-      localizeLocalState = obj => {
-        const state = reduce(obj, (acc, v, k) => {
-          const localKey = k.replace(containerNamespace, '');
-          return {
-            ...acc,
-            [localKey]: local[localKey] && v ? v[this.instanceNamespace] : v
-          };
-        }, {});
-        return state;
-      }
+      localizeLocalState = obj => reduce(obj, (acc, v, k) => {
+        const localKey = k.replace(containerNamespace, '');
+        return {
+          ...acc,
+          [localKey]: local[localKey] && v ? v[this.instanceNamespace] : v
+        };
+      }, {});
 
       localizeProps = ({ ___local = {}, ...props }) => ({
         ...props,
         ...this.localizeLocalState(pick(___local, globalizedLocalKeys)),
         transition: (...args) => {
-          if (args.length === 1 && t.Object.is(args[args.length - 1])) {
+          if (args.length === 1 && t.Object.is(args[0])) {
             const patch = args[0];
             const localProps = this.globalizeLocalState(pick(patch, localKeys));
             const globalProps = omit(patch, localKeys);

--- a/src/localizePropsDecorator.js
+++ b/src/localizePropsDecorator.js
@@ -4,9 +4,15 @@ import { t, props } from 'tcomb-react';
 import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
 import reduce from 'lodash/reduce';
+import pick from 'lodash/pick';
+import omit from 'lodash/omit';
 import displayName from './displayName';
 
 export default function localizePropsDecorator({ containerNamespace, local }) {
+
+  const localKeys = Object.keys(local);
+  const globalizedLocalKeys = localKeys.map(k => `${containerNamespace}${k}`);
+
   const globalizeLocalKeys = obj => mapKeys(obj, (_, k) => {
     if (local[k]) {
       return `${containerNamespace}${k}`;
@@ -21,7 +27,9 @@ export default function localizePropsDecorator({ containerNamespace, local }) {
   const decorator = Component => {
     @skinnable(contains(Component))
     @props({
-      ...globalizedLocalTypes,
+      ___local: t.maybe(t.interface({
+        ...globalizedLocalTypes
+      }, { strict: false })),
       transition: t.Function
     }, { strict: false })
     class LocalizePropsWrapper extends React.Component {
@@ -30,30 +38,46 @@ export default function localizePropsDecorator({ containerNamespace, local }) {
       static _instanceCount = 0;
 
       globalizeLocalState = obj => reduce(obj, (acc, v, k) => {
-        const globalKey = local[k] ? `${containerNamespace}${k}` : k;
+        const globalKey = `${containerNamespace}${k}`;
+
+        const { ___local = {} } = this.props;
+
         return {
           ...acc,
-          [globalKey]: local[k] ? {
-            ...this.props[globalKey],
+          [globalKey]: {
+            ...___local[globalKey],
             [this.instanceNamespace]: v
-          } : v
+          }
         };
       }, {});
 
-      localizeLocalState = obj => reduce(obj, (acc, v, k) => {
-        const localKey = k.replace(containerNamespace, '');
-        return {
-          ...acc,
-          [localKey]: local[localKey] && v ? v[this.instanceNamespace] : v
-        };
-      }, {});
+      localizeLocalState = obj => {
+        const state = reduce(obj, (acc, v, k) => {
+          const localKey = k.replace(containerNamespace, '');
+          return {
+            ...acc,
+            [localKey]: local[localKey] && v ? v[this.instanceNamespace] : v
+          };
+        }, {});
+        return state;
+      }
 
-      localizeProps = props => this.localizeLocalState({
+      localizeProps = ({ ___local = {}, ...props }) => ({
         ...props,
+        ...this.localizeLocalState(pick(___local, globalizedLocalKeys)),
         transition: (...args) => {
           if (args.length === 1 && t.Object.is(args[args.length - 1])) {
-            const globalizedProps = this.globalizeLocalState(args[args.length - 1]);
-            return props.transition(globalizedProps);
+            const patch = args[0];
+            const localProps = this.globalizeLocalState(pick(patch, localKeys));
+            const globalProps = omit(patch, localKeys);
+
+            return props.transition({
+              ...globalProps,
+              ___local: {
+                ...___local,
+                ...localProps
+              }
+            });
           }
           throw new Error(`Sorry, local transitions do not yet support arguments ${args.map(v => typeof v).join(',')}`);
         }


### PR DESCRIPTION
Closes #58

## Test Plan

### tests performed
Tested on [this](https://github.com/buildo/webseed/tree/new-state-api) webseed branch (after `npm install` local versions of `state` and `react-container`)
- Everything works as expected
- changing transition in `HelloContainer` to something like `transition({ formal: 1 })` will throw an exception:
> Invalid value 1 supplied to AppState/formal: ?Boolean
- adding a field like `bar: true` to the same transition will throw with:
> Invalid additional prop "bar" supplied to AppState
- local params reach the queries (you can see a log printing the current `foo` value when the `user` query is called)
