### PR TITLE
#69: container should not connect to every query/command input param (closes #69)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import compact from 'lodash/compact';
 import flowRight from 'lodash/flowRight';
 import isUndefined from 'lodash/isUndefined';
 import identity from 'lodash/identity';
+import intersection from 'lodash/intersection';
 import { t, props } from 'tcomb-react';
 import { skinnable, pure, contains } from 'revenge';
 import _declareQueries from 'react-avenger/lib/queries';
@@ -33,6 +34,7 @@ const ContainerConfig = t.interface({
 }, { strict: true, name: 'ContainerConfig' });
 
 const DecoratorConfig = t.interface({
+  appState: t.Function,
   declareConnect: t.Function,
   declareQueries: t.maybe(t.Function),
   declareCommands: t.maybe(t.Function)
@@ -48,7 +50,7 @@ export function isLocalKey(key) {
   return key === '___local';
 }
 
-const decorator = ({ declareQueries, declareCommands, declareConnect }) => (Component, config = {}) => {
+const decorator = ({ declareQueries, declareCommands, declareConnect, appState }) => (Component, config = {}) => {
   const {
     isReady = defaultIsReady,
     connect, local, queries, commands,
@@ -68,11 +70,11 @@ const decorator = ({ declareQueries, declareCommands, declareConnect }) => (Comp
   const queriesInputTypes = queries && Object.keys(declaredQueries.InputType) || [];
   const declaredCommands = commands && declareCommands(commands);
   const commandsInputTypes = commands && Object.keys(declaredCommands.InputType) || [];
-  const declaredConnect = (connect || local || queries || commands) && declareConnect([
+  const declaredConnect = (connect || local || queries || commands) && declareConnect(intersection([
     ...difference(queriesInputTypes, Object.keys(local || {})),
     ...difference(commandsInputTypes, Object.keys(local || {})),
     ...(connect || [])
-  ].concat(local ? ['___local'] : []));
+  ].concat(local ? ['___local'] : []), Object.keys(appState.meta.props)));
   const reduceQueryProps = queries && reduceQueryPropsFn && reduceQueryPropsDecorator({ queries, reducer: reduceQueryPropsFn });
 
   const propsTypes = {
@@ -143,16 +145,15 @@ export default config => {
     config.declareConnect(decl, { killProps: ['params', 'query', 'router'], ...connectConfig })
   );
 
-
   return t.match(config,
     DecoratorConfig, () => decorator({ ...config, declareConnect }),
     PublicDecoratorConfig, () => {
       const {
-        declareQueries: dq, allQueries, declareCommands: dc, allCommands
+        declareQueries: dq, allQueries, declareCommands: dc, allCommands, appState
       } = config;
       const declareQueries = dq || (allQueries && _declareQueries(allQueries)) || undefined;
       const declareCommands = dc || (allCommands && _declareCommands(allCommands)) || undefined;
-      return decorator({ declareConnect, declareQueries, declareCommands });
+      return decorator({ declareConnect, declareQueries, declareCommands, appState });
     }
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -67,14 +67,16 @@ const decorator = ({ declareQueries, declareCommands, declareConnect, appState }
   const localizeProps = local && localizePropsDecorator({ containerNamespace, local });
 
   const declaredQueries = queries && declareQueries(queries, { querySync });
-  const queriesInputTypes = queries && Object.keys(declaredQueries.InputType) || [];
   const declaredCommands = commands && declareCommands(commands);
+
+  const queriesInputTypes = queries && Object.keys(declaredQueries.InputType) || [];
   const commandsInputTypes = commands && Object.keys(declaredCommands.InputType) || [];
-  const declaredConnect = (connect || local || queries || commands) && declareConnect(intersection([
-    ...difference(queriesInputTypes, Object.keys(local || {})),
-    ...difference(commandsInputTypes, Object.keys(local || {})),
-    ...(connect || [])
-  ].concat(local ? ['___local'] : []), Object.keys(appState.meta.props)));
+  const inputTypesFromState = intersection([...queriesInputTypes, ...commandsInputTypes], Object.keys(appState.meta.props));
+
+  const declaredConnect = (connect || local || queries || commands) && declareConnect([
+    ...(connect || []),
+    ...(inputTypesFromState || [])
+  ].concat(local ? ['___local'] : []));
   const reduceQueryProps = queries && reduceQueryPropsFn && reduceQueryPropsDecorator({ queries, reducer: reduceQueryPropsFn });
 
   const propsTypes = {


### PR DESCRIPTION
Closes #69

## Test Plan

### tests performed
Tested on GDSM/web:
- install local `react-container` and `state` from: https://github.com/buildo/state/pull/38
- remove all the unwanted keys from `state.js` (note: in gdsm/web, `searchId`, `selectFareId` and `reservationId` are marked as unneeded, but they're actually part of the state, so we should keep them with type `t.maybe(t.String)`)
- change the last line in `state.js` file to `export const { run, connect, appState } = init(AppState)`
- change `container.js` importing `{ appState } from 'state'` and passing it to the `containerFactory`
