### PR TITLE
#75: cleanProps is not working (closes #75)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ const decorator = ({ declareQueries, declareCommands, declareConnect, appState }
 
   // used to filer out props that are "unwanted" below
   const cleanProps = omit(difference(
-    Object.keys({ ...queriesInputTypes, ...commandsInputTypes }),
+    [...queriesInputTypes, ...commandsInputTypes],
     (connect || []).concat(Object.keys(local || {})).concat(Object.keys(__props || {})).concat(queries || []).concat(commands || [])
   ));
 


### PR DESCRIPTION
Closes #75

## Test Plan

### tests performed
- log every prop of `mapProps` in a container that has an authenticated query
=> `token` is **not** passed to `mapProps`

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
